### PR TITLE
Unified Matmul Visualization in matrix view and graph view

### DIFF
--- a/src/utils/graphAnimationHelper.tsx
+++ b/src/utils/graphAnimationHelper.tsx
@@ -377,7 +377,7 @@ export function displayerHandler(node: any, aggregatedData: any, calculatedData:
         .attr("font-size", "7")
         .attr("fill", Math.abs(weights[index][1][i]) > 0.7 ? "white" : "black");
 
-    // 绘制输出数据的矩形和文本
+    // 绘制输出数据的矩形和文本 
     innerGroup.append("rect")
         .attr("x", 70 - 30 + 100 + 60 + 20)
         .attr("y", displayHeight - 10 - 9 + equationYOffest)

--- a/src/utils/graphAnimationHelper.tsx
+++ b/src/utils/graphAnimationHelper.tsx
@@ -283,7 +283,7 @@ export function displayerHandler(node: any, aggregatedData: any, calculatedData:
             .attr("x", 70 - 40)
             .attr("y", displayHeight - 10)
             .attr("xml:space", "preserve")
-            .text("=      x       +      x        ···  =     ")
+            .text("=      x       +      x       ···   =     ")
             .attr("class", "math-displayer")
             .attr("font-size", "15");
     } else {
@@ -291,7 +291,7 @@ export function displayerHandler(node: any, aggregatedData: any, calculatedData:
             .attr("x", 70 - 40)
             .attr("y", displayHeight - 10)
             .attr("xml:space", "preserve")
-            .text("=      x       +      x        ···  =     ")
+            .text("=      x       +      x       ···   =     ")
             .attr("class", "math-displayer")
             .attr("font-size", "15");
     }

--- a/src/utils/graphAnimationHelper.tsx
+++ b/src/utils/graphAnimationHelper.tsx
@@ -283,7 +283,7 @@ export function displayerHandler(node: any, aggregatedData: any, calculatedData:
             .attr("x", 70 - 40)
             .attr("y", displayHeight - 10)
             .attr("xml:space", "preserve")
-            .text("=      x       +      x        ...  =     ")
+            .text("=      x       +      x        ···  =     ")
             .attr("class", "math-displayer")
             .attr("font-size", "15");
     } else {
@@ -291,7 +291,7 @@ export function displayerHandler(node: any, aggregatedData: any, calculatedData:
             .attr("x", 70 - 40)
             .attr("y", displayHeight - 10)
             .attr("xml:space", "preserve")
-            .text("=      x       +      x        ...  =     ")
+            .text("=      x       +      x        ···  =     ")
             .attr("class", "math-displayer")
             .attr("font-size", "15");
     }

--- a/src/utils/graphAnimationHelper.tsx
+++ b/src/utils/graphAnimationHelper.tsx
@@ -1,5 +1,5 @@
 import * as d3 from "d3";
-import { create, all, matrix, i } from "mathjs";
+import { create, all, matrix, i, e } from "mathjs";
 import { State, flipHorizontally, flipVertically, myColor } from "./utils";
 import { roundToTwo } from "@/components/WebUtils";
 
@@ -229,8 +229,8 @@ export function displayerHandler(node: any, aggregatedData: any, calculatedData:
     
     for (let j = 0; j < weightMat[i].length; j++) {
         innerGroup.append("rect")
-            .attr("x", 150)
-            .attr("y", 40 + wmRectL * j)
+            .attr("x", 160)
+            .attr("y", 35 + wmRectL * j)
             .attr("width", 7)
             .attr("height", wmRectL)
             .attr("fill", myColor(weightMat[i][j]))
@@ -277,19 +277,20 @@ export function displayerHandler(node: any, aggregatedData: any, calculatedData:
         .attr("class", "math-displayer")
         .attr("font-size", "20");
 
-
+    const equationYOffest = -5;
+    const equationValueYOffest = 2.5;
     if (mode === 1 && node.graphIndex === 4) {
         innerGroup.append("text")
             .attr("x", 70 - 40)
-            .attr("y", displayHeight - 10)
+            .attr("y", displayHeight - 10 + equationYOffest + equationValueYOffest)
             .attr("xml:space", "preserve")
-            .text("=      x       +      x       ···   =     ")
+            .text("=      x       +      x       ...   =     ")
             .attr("class", "math-displayer")
             .attr("font-size", "15");
     } else {
         innerGroup.append("text")
             .attr("x", 70 - 40)
-            .attr("y", displayHeight - 10)
+            .attr("y", displayHeight - 10 + equationYOffest + equationValueYOffest)
             .attr("xml:space", "preserve")
             .text("=      x       +      x       ···   =     ")
             .attr("class", "math-displayer")
@@ -299,7 +300,7 @@ export function displayerHandler(node: any, aggregatedData: any, calculatedData:
     // 1
     innerGroup.append("rect")
         .attr("x", 70 - 30 + 5)
-        .attr("y", displayHeight - 10 - 9)
+        .attr("y", displayHeight - 10 - 9 + equationYOffest)
         .attr("width", 17)
         .attr("height", 17)
         .attr("class", `math-displayer`)
@@ -310,7 +311,7 @@ export function displayerHandler(node: any, aggregatedData: any, calculatedData:
 
     innerGroup.append("text")
         .attr("x", 70 - 30 + 5)
-        .attr("y", displayHeight - 10 - 2)
+        .attr("y", displayHeight - 10 - 2 + equationYOffest + equationValueYOffest)
         .text(roundToTwo(aggregatedData[0]))
         .attr("class", "math-displayer")
         .attr("font-size", "7")
@@ -319,7 +320,7 @@ export function displayerHandler(node: any, aggregatedData: any, calculatedData:
     // 2
     innerGroup.append("rect")
         .attr("x", 70 - 30 + 25 + 10 + 5)
-        .attr("y", displayHeight - 10 - 9)
+        .attr("y", displayHeight - 10 - 9 + equationYOffest)
         .attr("width", 17)
         .attr("height", 17)
         .attr("class", `math-displayer`)
@@ -330,7 +331,7 @@ export function displayerHandler(node: any, aggregatedData: any, calculatedData:
 
     innerGroup.append("text")
         .attr("x", 70 - 30 + 25 + 10 + 5)
-        .attr("y", displayHeight - 10 - 2)
+        .attr("y", displayHeight - 10 - 2 + equationYOffest + equationValueYOffest)
         .text(roundToTwo(weights[index][0][i]))
         .attr("class", "math-displayer")
         .attr("font-size", "7")
@@ -339,7 +340,7 @@ export function displayerHandler(node: any, aggregatedData: any, calculatedData:
     // 3
     innerGroup.append("rect")
         .attr("x", 70 - 30 + 45 + 20 + 10)
-        .attr("y", displayHeight - 10 - 9)
+        .attr("y", displayHeight - 10 - 9 + equationYOffest)
         .attr("width", 17)
         .attr("height", 17)
         .attr("class", `math-displayer`)
@@ -350,7 +351,7 @@ export function displayerHandler(node: any, aggregatedData: any, calculatedData:
 
     innerGroup.append("text")
         .attr("x", 70 - 30 + 45 + 20 + 10)
-        .attr("y", displayHeight - 10 - 2)
+        .attr("y", displayHeight - 10 - 2 + equationYOffest + equationValueYOffest)
         .text(roundToTwo(aggregatedData[1]))
         .attr("class", "math-displayer")
         .attr("font-size", "7")
@@ -359,7 +360,7 @@ export function displayerHandler(node: any, aggregatedData: any, calculatedData:
     // 4
     innerGroup.append("rect")
         .attr("x", 70 - 30 + 65 + 30 + 15)
-        .attr("y", displayHeight - 10 - 9)
+        .attr("y", displayHeight - 10 - 9 + equationYOffest)
         .attr("width", 17)
         .attr("height", 17)
         .attr("class", `math-displayer`)
@@ -370,7 +371,7 @@ export function displayerHandler(node: any, aggregatedData: any, calculatedData:
 
     innerGroup.append("text")
         .attr("x", 70 - 30 + 65 + 30 + 15)
-        .attr("y", displayHeight - 10 - 2)
+        .attr("y", displayHeight - 10 - 2 + equationYOffest + equationValueYOffest)
         .text(roundToTwo(weights[index][1][i]))
         .attr("class", "math-displayer")
         .attr("font-size", "7")
@@ -379,9 +380,9 @@ export function displayerHandler(node: any, aggregatedData: any, calculatedData:
     // 绘制输出数据的矩形和文本
     innerGroup.append("rect")
         .attr("x", 70 - 30 + 100 + 60 + 20)
-        .attr("y", displayHeight - 10 - 9)
-        .attr("width", 14)
-        .attr("height", 14)
+        .attr("y", displayHeight - 10 - 9 + equationYOffest)
+        .attr("width", 17)
+        .attr("height", 17)
         .attr("class", `math-displayer`)
         .style("fill", myColor(calculatedData[i]))
         .style("stroke-width", 0.1)
@@ -390,7 +391,7 @@ export function displayerHandler(node: any, aggregatedData: any, calculatedData:
 
     innerGroup.append("text")
         .attr("x", 70 - 30 + 100 + 60 + 20)
-        .attr("y", displayHeight - 10 - 2)
+        .attr("y", displayHeight - 10 - 2 + equationYOffest + equationValueYOffest)
         .text(roundToTwo(calculatedData[i]))
         .attr("class", "math-displayer")
         .attr("font-size", "7")

--- a/src/utils/matInteractionUtils.tsx
+++ b/src/utils/matInteractionUtils.tsx
@@ -1138,7 +1138,7 @@ export function drawDotProduct(
             aggregatedVector[1],
             weightVector[1]
         ];
-        let operators = ["x", "  +", "   x", "          ...    = "];
+        let operators = ["x", "  +", "   x", "       ···    = "];
 
         if(weightVector.length==2&&aggregatedVector.length==2){
             operators[3] = "           =";
@@ -1147,7 +1147,8 @@ export function drawDotProduct(
         //matmul-displayer interaction
         let displayerOffset = -150;
         if(curveDir==1)displayerOffset = 100;
-        let displayerX = coordFeatureVis[0];
+        let globalXOffest = 20;
+        let displayerX = coordFeatureVis[0] + globalXOffest;
         let displayerY = coordFeatureVis[1] + displayerOffset + 20;
 
     const displayW = 300;
@@ -1161,7 +1162,7 @@ export function drawDotProduct(
 
         tooltip
             .append("rect")
-            .attr("x", displayerX)
+            .attr("x", displayerX - globalXOffest)
             .attr("y", displayerY - 10)
             .attr("y", displayerY - 10)
             .attr("width", displayW)
@@ -1178,7 +1179,7 @@ export function drawDotProduct(
         const titleXOffset = 50;
         tooltip
             .append("text")
-            .attr("x", displayerX + titleXOffset)
+            .attr("x", displayerX + titleXOffset - globalXOffest)
             .attr("y", displayerY + titleYOffset)
             .text("Matmul Visualization")
             .attr("class", "matmul-displayer procVis")
@@ -1189,7 +1190,7 @@ export function drawDotProduct(
         
         let h = vectorLength / aggregatedVector.length;
         let h2 = vectorLength / weightVector.length;
-        let w = 11.25;
+        let w = 14;
         if(h>vectorLength / weightVector.length)h = vectorLength / weightVector.length;
 
 
@@ -1263,9 +1264,9 @@ export function drawDotProduct(
             const text = tooltip
             .append("text").attr("xml:space", "preserve")
             .attr("x", displayerX + 3 + unitSize*(i+1) + 25*(i+1))
-            .attr("y", displayerY + vectorLength/2 + 20 )
+            .attr("y", displayerY + vectorLength/2 + 25 )
             .text(operators[i])
-            .attr("font-size", unitSize*1.25)
+            .attr("font-size", 15)
             .attr("class", "matmul-displayer procVis")
             .raise();
             if(i==operators.length-1){
@@ -1300,8 +1301,8 @@ export function drawDotProduct(
         for(let i=0; i<aggregatedVector.length; i++){
             tooltip
                 .append("rect")
-                .attr("x", displayerX + eqXOffset+i*h/2)
-                .attr("y", displayerY + vectorLength/2)
+                .attr("x", displayerX + eqXOffset * 2 + i*h/2)
+                .attr("y", displayerY + eqYOffset * -0.5 + vectorLength/2)
                 .attr("width", h/2)
                 .attr("height", w/2)
                 .attr("fill", myColor(aggregatedVector[i]))
@@ -1312,8 +1313,7 @@ export function drawDotProduct(
         for(let i=0; i<weightVector.length; i++){
             tooltip
                 .append("rect")
-                .attr("x", displayerX + eqXOffset * 5)
-                .attr("x", displayerX + eqXOffset * 5)
+                .attr("x", displayerX + eqXOffset * 5.5)
                 .attr("y", displayerY + eqYOffset + i*h2/2)
                 .attr("width", w/2)
                 .attr("height", h2/2)
@@ -1321,28 +1321,29 @@ export function drawDotProduct(
                 .attr("class", "procVis matmul-displayer").raise();
         }
 
-        //draw franes
+        //draw frames
         tooltip
             .append("rect")
-            .attr("x", displayerX + eqXOffset)
-            .attr("y", displayerY + vectorLength/2)
+            .attr("x", displayerX + eqXOffset * 2)
+            .attr("y", displayerY + eqYOffset * -0.5 + vectorLength/2)
             .attr("width", h/2 * aggregatedVector.length)
             .attr("height", w/2)
             .attr("fill", "none")
             .attr("class", "procVis matmul-displayer")
-            .attr("stroke", "black")
+            .style("stroke-width", 0.1)
+            .style("stroke", "grey")
             .raise();
 
             tooltip
             .append("rect")
-            .attr("x", displayerX + eqXOffset * 5)
-            .attr("x", displayerX + eqXOffset * 5)
+            .attr("x", displayerX + eqXOffset * 5.5)
             .attr("y", displayerY + eqYOffset)
             .attr("width", w/2)
             .attr("height", h2/2 * weightVector.length)
             .attr("fill", "none")
             .attr("class", "procVis matmul-displayer")
-            .attr("stroke", "black")
+            .style("stroke-width", 0.1)
+            .style("stroke", "grey")
             .raise();
 
            // 定义缩放比例

--- a/src/utils/matInteractionUtils.tsx
+++ b/src/utils/matInteractionUtils.tsx
@@ -1138,7 +1138,7 @@ export function drawDotProduct(
             aggregatedVector[1],
             weightVector[1]
         ];
-        let operators = ["x", "  +", "   x", "       ···    = "];
+        let operators = ["x", "  +", "   x", "      ···    = "];
 
         if(weightVector.length==2&&aggregatedVector.length==2){
             operators[3] = "           =";
@@ -1180,7 +1180,7 @@ export function drawDotProduct(
         tooltip
             .append("text")
             .attr("x", displayerX + titleXOffset - globalXOffest)
-            .attr("y", displayerY + titleYOffset)
+            .attr("y", displayerY + titleYOffset * 3)
             .text("Matmul Visualization")
             .attr("class", "matmul-displayer procVis")
             .attr("font-size", 20)
@@ -1188,10 +1188,10 @@ export function drawDotProduct(
         
         const vectorLength = displayH - titleYOffset;
         
-        let h = vectorLength / aggregatedVector.length;
-        let h2 = vectorLength / weightVector.length;
+        let h = vectorLength / aggregatedVector.length * 0.75;
+        let h2 = vectorLength / weightVector.length * 0.75;
         let w = 14;
-        if(h>vectorLength / weightVector.length)h = vectorLength / weightVector.length;
+        if(h>vectorLength / weightVector.length)h = h2
 
 
 
@@ -1214,7 +1214,7 @@ export function drawDotProduct(
             .attr("y", displayerY + vectorLength/2 + 3)
             .text(",")
             .attr("class", "matmul-displayer procVis")
-            .attr("font-size", titleYOffset*2)
+            .attr("font-size", 20)
             .attr("fill", "black");
         
         tooltip
@@ -1228,11 +1228,11 @@ export function drawDotProduct(
 
         tooltip
             .append("text")
-            .attr("x", displayerX + 3)
-            .attr("y", displayerY + vectorLength/2 + 20)
+            .attr("x", displayerX -5)
+            .attr("y", displayerY + vectorLength/2 + 25)
             .text("=")
             .attr("class", "matmul-displayer procVis")
-            .attr("font-size", titleYOffset*2)
+            .attr("font-size", 15)
             .attr("fill", "black");
 
         for(let i=0; i<dataSamples.length; i++){
@@ -1242,7 +1242,8 @@ export function drawDotProduct(
                 .attr("y", displayerY + vectorLength/2 + 20 - unitSize)
                 .attr("width", unitSize*2.5)
                 .attr("height", unitSize*2.5)
-                .style("stroke", "black")
+                .style("stroke", "grey")
+                .style("stroke-width", 0.1)
                 .attr("fill", myColor(dataSamples[i]))
                 .attr("class", "matmul-displayer procVis")
                 .raise();
@@ -1280,7 +1281,8 @@ export function drawDotProduct(
             .attr("y", displayerY + vectorLength/2 + 20 - unitSize)
             .attr("width", unitSize*2.5)
             .attr("height", unitSize*2.5)
-            .style("stroke", "black")
+            .style("stroke", "grey")
+            .style("stroke-width", 0.1)
             .attr("fill", myColor(currentVal))
             .attr("class", "matmul-displayer procVis")
             .raise();
@@ -1305,6 +1307,8 @@ export function drawDotProduct(
                 .attr("y", displayerY + eqYOffset * -0.5 + vectorLength/2)
                 .attr("width", h/2)
                 .attr("height", w/2)
+                .attr("stroke", "gray")
+                .attr("stroke-width", 0.1)
                 .attr("fill", myColor(aggregatedVector[i]))
                 .attr("class", "procVis matmul-displayer").raise();
         }
@@ -1314,37 +1318,14 @@ export function drawDotProduct(
             tooltip
                 .append("rect")
                 .attr("x", displayerX + eqXOffset * 5.5)
-                .attr("y", displayerY + eqYOffset + i*h2/2)
+                .attr("y", displayerY + eqYOffset * 1.5 + i*h2/2)
                 .attr("width", w/2)
                 .attr("height", h2/2)
+                .attr("stroke", "gray")
+                .attr("stroke-width", 0.1)
                 .attr("fill", myColor(weightVector[i]))
                 .attr("class", "procVis matmul-displayer").raise();
         }
-
-        //draw frames
-        tooltip
-            .append("rect")
-            .attr("x", displayerX + eqXOffset * 2)
-            .attr("y", displayerY + eqYOffset * -0.5 + vectorLength/2)
-            .attr("width", h/2 * aggregatedVector.length)
-            .attr("height", w/2)
-            .attr("fill", "none")
-            .attr("class", "procVis matmul-displayer")
-            .style("stroke-width", 0.1)
-            .style("stroke", "grey")
-            .raise();
-
-            tooltip
-            .append("rect")
-            .attr("x", displayerX + eqXOffset * 5.5)
-            .attr("y", displayerY + eqYOffset)
-            .attr("width", w/2)
-            .attr("height", h2/2 * weightVector.length)
-            .attr("fill", "none")
-            .attr("class", "procVis matmul-displayer")
-            .style("stroke-width", 0.1)
-            .style("stroke", "grey")
-            .raise();
 
            // 定义缩放比例
         const scaleFactor = 1.5;

--- a/src/utils/matInteractionUtils.tsx
+++ b/src/utils/matInteractionUtils.tsx
@@ -1138,7 +1138,7 @@ export function drawDotProduct(
             aggregatedVector[1],
             weightVector[1]
         ];
-        let operators = ["x", "+", "  x", "          ......    = "];
+        let operators = ["x", "  +", "   x", "          ...    = "];
 
         if(weightVector.length==2&&aggregatedVector.length==2){
             operators[3] = "           =";
@@ -1182,8 +1182,7 @@ export function drawDotProduct(
             .attr("y", displayerY + titleYOffset)
             .text("Matmul Visualization")
             .attr("class", "matmul-displayer procVis")
-            .attr("font-size", titleYOffset*2)
-            .attr("font-size", titleYOffset*2)
+            .attr("font-size", 20)
             .attr("fill", "black");
         
         const vectorLength = displayH - titleYOffset;
@@ -1205,8 +1204,7 @@ export function drawDotProduct(
             .attr("y", displayerY + vectorLength/2 + 3)
             .text("dot(")
             .attr("class", "matmul-displayer procVis")
-            .attr("font-size", titleYOffset*2)
-            .attr("font-size", titleYOffset*2)
+            .attr("font-size", 20)
             .attr("fill", "black");
 
         tooltip
@@ -1216,7 +1214,6 @@ export function drawDotProduct(
             .text(",")
             .attr("class", "matmul-displayer procVis")
             .attr("font-size", titleYOffset*2)
-            .attr("font-size", titleYOffset*2)
             .attr("fill", "black");
         
         tooltip
@@ -1225,8 +1222,7 @@ export function drawDotProduct(
             .attr("y", displayerY + vectorLength/2 + 3)
             .text(")")
             .attr("class", "matmul-displayer procVis")
-            .attr("font-size", titleYOffset*2)
-            .attr("font-size", titleYOffset*2)
+            .attr("font-size", 20)
             .attr("fill", "black");
 
         tooltip
@@ -1235,7 +1231,6 @@ export function drawDotProduct(
             .attr("y", displayerY + vectorLength/2 + 20)
             .text("=")
             .attr("class", "matmul-displayer procVis")
-            .attr("font-size", titleYOffset*2)
             .attr("font-size", titleYOffset*2)
             .attr("fill", "black");
 
@@ -1297,7 +1292,6 @@ export function drawDotProduct(
                 .attr("y", displayerY + vectorLength/2 + 20 + unitSize/2)
                 .text(roundToTwo(currentVal))
                 .attr("class", "matmul-displayer procVis")
-                .attr("font-size", unitSize * 0.9)
                 .attr("font-size", unitSize * 0.9)
                 .attr("fill", color);
         


### PR DESCRIPTION
Unified Matmul Visualization in matrix view and graph view. 
For text, unified font size and layout, replaced "." in the equation to "·". 
For rectangle objects, unified edge color to grey, edge width to 0.1 and rectangle width. 
The two visualizations for matmul should look very similar now.